### PR TITLE
Issue 34 native vlan

### DIFF
--- a/roles/os6_vlan/templates/os6_vlan.j2
+++ b/roles/os6_vlan/templates/os6_vlan.j2
@@ -96,6 +96,31 @@ exit
   {% endfor -%}
   {%- for cmd in cmd_dict -%}
 interface {{cmd}}
+
+    {# Begin native vlan
+     Persistent problems: 
+     - if the interface is in tunk mode but has no tagged member, the untagged vlan will not be set as native.
+     - the access vlan will still be set even if the interface is in trunk mode
+    #}
+    {%- for key  in os6_vlan.keys() -%}
+      {% if 'vlan' in key %}
+        {%- set vlan_id = key.split(" ") -%}
+        {%- set vlan_vars = os6_vlan[key] -%}
+        {% if vlan_vars.state is defined and vlan_vars.state=="present" -%}
+          {% if vlan_vars.untagged_members is defined -%}
+            {%- for ports in vlan_vars.untagged_members -%}
+              {% if ports.port is defined and ports.port -%}
+                {% if ports.port == cmd -%}
+switchport trunk native vlan {{ vlan_id[1] }}
+                {% endif -%}
+              {% endif -%}
+            {% endfor -%}
+          {% endif -%}
+        {% endif -%}
+      {% endif -%} 
+    {% endfor -%}
+    {# END native vlan #}
+
     {% if 'tagged_members_state' in os6_vlan and os6_vlan['tagged_members_state']=='absent' %}
 no switchport trunk allowed vlan
     {% else %}

--- a/roles/os6_vlan/templates/os6_vlan.j2
+++ b/roles/os6_vlan/templates/os6_vlan.j2
@@ -23,113 +23,94 @@ os6_vlan:
 
 #########################################}
 {% if os6_vlan is defined and os6_vlan -%}
-{%- for key  in os6_vlan.keys() -%}
-{% if 'vlan' in key %}
-{%- set vlan_id = key.split(" ") -%}
-{%- set vlan_vars = os6_vlan[key] -%}
-  {% if vlan_vars.state is defined and vlan_vars.state=="absent" -%}
+  {%- for key  in os6_vlan.keys() -%}
+    {% if 'vlan' in key %}
+      {%- set vlan_id = key.split(" ") -%}
+      {%- set vlan_vars = os6_vlan[key] -%}
+      {% if vlan_vars.state is defined and vlan_vars.state=="absent" -%}
 no vlan {{ vlan_id[1] }}
-  {%- else -%}
+      {%- else -%}
 vlan {{ vlan_id[1] }}
-    {% if vlan_vars.name is defined -%}
-      {% if vlan_vars.name-%}
+        {% if vlan_vars.name is defined -%}
+          {% if vlan_vars.name-%}
 name "{{ vlan_vars.name }}"
-      {% else -%}
-no name
-      {% endif %}
-    {% endif %}
-exit
-    {% if vlan_vars.untagged_members is defined -%}
-      {%- for ports in vlan_vars.untagged_members -%}
-        {% if ports.port is defined and ports.port -%}
-          {% if ports.state is defined and ports.state == "absent" -%}
-interface {{ ports.port }}
-no switchport access vlan
           {% else -%}
-interface {{ ports.port }}
-switchport access vlan {{ vlan_id[1] }}
-          {% endif -%}
+no name
+          {% endif %}
+        {% endif %}
+exit
+        {% if vlan_vars.untagged_members is defined -%}
+          {%- for ports in vlan_vars.untagged_members -%}
+            {% if ports.port is defined and ports.port -%}
+              {% if ports.state is defined and ports.state == "absent" -%}
+  interface {{ ports.port }}
+  no switchport access vlan
+              {% else -%}
+  interface {{ ports.port }}
+  switchport access vlan {{ vlan_id[1] }}
+              {% endif -%}
+            {% endif -%}
+  exit
+          {% endfor -%}
         {% endif -%}
-exit
-      {% endfor -%}
+      {% endif -%}
     {% endif -%}
-  {% endif -%}
-{% endif -%}
-{% endfor -%}
-{%- set cmd_dict = {} -%}
-{%- for key  in os6_vlan.keys() -%}
-{% if 'vlan' in key %}
-{%- set vlan_id = key.split(" ") -%}
-{%- set vlan_vars = os6_vlan[key] -%}
-{%- set tagged_vlans = [] -%}
-{%- set tagged_members_present = [] -%}
-{%- set tagged_members_absent= [] -%}
-{% if vlan_vars.tagged_members is defined and vlan_vars.tagged_members -%}
-      {%- for ports in vlan_vars.tagged_members -%}
-        {% if ports.port is defined and ports.port -%}
-        {%- set port = ports.port -%}
-        {% if ports.state is defined and ports.state == 'absent' -%} 
-          {% if port in cmd_dict and 'absent' in cmd_dict[port] -%}
-            {%- set tmp_vlan_list=cmd_dict[port]['absent'] -%}
-            {%- set x=tmp_vlan_list.extend([vlan_id[1]]) -%}
-            {%- set x=cmd_dict[port].update({'absent': tmp_vlan_list}) -%}
-          {%- elif port in cmd_dict and 'absent' not in cmd_dict[port] -%}
-            {%- set x=cmd_dict[port].update({'absent': [vlan_id[1]]}) -%}
-          {%- else -%}
-            {%- set x=cmd_dict.update({port: {'absent': [vlan_id[1]]}}) -%}
-          {% endif -%}
-        {%- else -%}
-          {% if port in cmd_dict and 'present' in cmd_dict[port] -%}
-            {%- set tmp_vlan_list=cmd_dict[port]['present'] -%}
-            {%- set x=tmp_vlan_list.extend([vlan_id[1]]) -%}
-            {%- set x=cmd_dict[port].update({'present': tmp_vlan_list}) -%}
-          {%- elif port in cmd_dict and 'present' not in cmd_dict[port] -%}
-            {%- set x=cmd_dict[port].update({'present': [vlan_id[1]]}) -%}
-          {%- else -%}
-            {%- set x=cmd_dict.update({port: {'present': [vlan_id[1]]}}) -%}
-          {% endif -%}
-        {% endif -%} 
-        {% endif -%} 
-      {% endfor -%}
-{% endif -%} 
-{% endif -%} 
   {% endfor -%}
-{%- for cmd in cmd_dict -%}
+  {%- set cmd_dict = {} -%}
+  {%- for key  in os6_vlan.keys() -%}
+    {% if 'vlan' in key %}
+      {%- set vlan_id = key.split(" ") -%}
+      {%- set vlan_vars = os6_vlan[key] -%}
+      {%- set tagged_vlans = [] -%}
+      {%- set tagged_members_present = [] -%}
+      {%- set tagged_members_absent= [] -%}
+      {% if vlan_vars.tagged_members is defined and vlan_vars.tagged_members -%}
+        {%- for ports in vlan_vars.tagged_members -%}
+          {% if ports.port is defined and ports.port -%}
+            {%- set port = ports.port -%}
+            {% if ports.state is defined and ports.state == 'absent' -%} 
+              {% if port in cmd_dict and 'absent' in cmd_dict[port] -%}
+                {%- set tmp_vlan_list=cmd_dict[port]['absent'] -%}
+                {%- set x=tmp_vlan_list.extend([vlan_id[1]]) -%}
+                {%- set x=cmd_dict[port].update({'absent': tmp_vlan_list}) -%}
+              {%- elif port in cmd_dict and 'absent' not in cmd_dict[port] -%}
+                {%- set x=cmd_dict[port].update({'absent': [vlan_id[1]]}) -%}
+              {%- else -%}
+                {%- set x=cmd_dict.update({port: {'absent': [vlan_id[1]]}}) -%}
+              {% endif -%}
+            {%- else -%}
+              {% if port in cmd_dict and 'present' in cmd_dict[port] -%}
+                {%- set tmp_vlan_list=cmd_dict[port]['present'] -%}
+                {%- set x=tmp_vlan_list.extend([vlan_id[1]]) -%}
+                {%- set x=cmd_dict[port].update({'present': tmp_vlan_list}) -%}
+              {%- elif port in cmd_dict and 'present' not in cmd_dict[port] -%}
+                {%- set x=cmd_dict[port].update({'present': [vlan_id[1]]}) -%}
+              {%- else -%}
+                {%- set x=cmd_dict.update({port: {'present': [vlan_id[1]]}}) -%}
+              {% endif -%}
+            {% endif -%} 
+          {% endif -%} 
+        {% endfor -%}
+      {% endif -%} 
+    {% endif -%} 
+  {% endfor -%}
+  {%- for cmd in cmd_dict -%}
 interface {{cmd}}
-{% if 'tagged_members_state' in os6_vlan and os6_vlan['tagged_members_state']=='absent' %}
+    {% if 'tagged_members_state' in os6_vlan and os6_vlan['tagged_members_state']=='absent' %}
 no switchport trunk allowed vlan
-{% else %}
-{% for cmd_item in cmd_dict[cmd] %}
-{% if 'present' == cmd_item -%}
-{% set sort_list =  cmd_dict[cmd]['present']| sort %}
-{% elif 'absent' in cmd_item -%}
-{% set sort_list =  cmd_dict[cmd]['absent']| sort %}
-{% endif %}
-{% set range_list = [] %}
-{% set temp = {'temp': []} %}
-{% for i in range(sort_list|length) %}
-{% set x=temp['temp'].extend([sort_list[i]]) %}
-{% if (i != sort_list|length -1 and sort_list[i+1]|int - sort_list[i]|int > 1) or (i == sort_list|length -1) %}
-{% if temp['temp']|first != temp['temp']|last %}
-{% set x=range_list.extend([temp['temp']|first|string+'-'+temp['temp']|last|string]) %}
-{% set x=temp.update({'temp': []}) %}
-{% else %}
-{% set x=range_list.extend([temp['temp']|last|string]) %}
-{% set x=temp.update({'temp': []}) %}
-{% endif %}
-{% endif %}
-{% endfor %}
-{% if 'present' == cmd_item -%}
-{% if 'tagged_members_append' in os6_vlan and os6_vlan['tagged_members_append'] %}
-switchport trunk allowed vlan add {{ range_list| join(',') }}
-{% else %}
-switchport trunk allowed vlan {{ range_list| join(',') }}
-{% endif -%}
-{% elif 'absent' == cmd_item -%}
-switchport trunk allowed vlan remove {{ range_list| join(',') }}
-{% endif -%}
-{% endfor -%}
+    {% else %}
+      {% for cmd_item in cmd_dict[cmd] %}
+        {% if 'present' == cmd_item -%}
+          {% if 'tagged_members_append' in os6_vlan and os6_vlan['tagged_members_append'] %}
+switchport trunk allowed vlan add {{ cmd_dict[cmd]['present']| join(',') }}
+          {% else %}
+switchport trunk allowed vlan {{ cmd_dict[cmd]['present']| join(',') }}
+          {% endif -%}
+        {% elif 'absent' == cmd_item -%}
+switchport trunk allowed vlan remove {{ cmd_dict[cmd]['absent']| join(',') }}
+        {% endif -%}
+      {% endfor -%}
 exit
-{% endif -%}
-{% endfor -%}
+    {% endif -%}
+  {% endfor -%}
 {% endif -%}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding support for trunk native vlan
2 problems still persist:
     - if the interface is in tunk mode but has no tagged member, the untagged vlan will not be set as native.
     - the access vlan will still be set even if the interface is in trunk mode
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #34 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
os6_vlan
##### ADDITIONAL INFORMATION

