### PR TITLE
Update cliconf plugin os6.py - error with grep

### DIFF
--- a/plugins/cliconf/os6.py
+++ b/plugins/cliconf/os6.py
@@ -49,15 +49,15 @@ class Cliconf(CliconfBase):
         reply = self.get('show version')
         data = to_text(reply, errors='surrogate_or_strict').strip()
 
-        match = re.search(r'Software Version (\S+)', data)
+        match = re.search(r'Image File........................ (\S+)', data)
         if match:
             device_info['network_os_version'] = match.group(1)
 
-        match = re.search(r'System Type (\S+)', data, re.M)
+        match = re.search(r'Machine Type...................... (\S+)', data, re.M)
         if match:
             device_info['network_os_model'] = match.group(1)
 
-        reply = self.get('show running-config | grep hostname')
+        reply = self.get('show running-config | include hostname')
         data = to_text(reply, errors='surrogate_or_strict').strip()
         match = re.search(r'^hostname (.+)', data, re.M)
         if match:


### PR DESCRIPTION
An erroneous grep is used with show running-config command, breaking every functionality of cli_config agnostic module

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
