### PR TITLE
Update os6.py

### DIFF
--- a/plugins/cliconf/os6.py
+++ b/plugins/cliconf/os6.py
@@ -23,7 +23,7 @@ __metaclass__ = type
 
 DOCUMENTATION = """
 ---
-cliconf: os6
+name: os6
 short_description: Use os6 cliconf to run command on Dell OS6 platform
 description:
   - This os6 plugin provides low level abstraction apis for


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replaced 'cliconf' to 'name' under DOCUMENTATION in plugins/cliconf/os6.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/cliconf/os6.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The following errors were seen during sanity run.
ERROR: plugins/cliconf/os6.py:0:0: invalid-documentation: DOCUMENTATION.cliconf: extra keys not allowed @ data['cliconf']. Got 'os6'
ERROR: plugins/cliconf/os6.py:0:0: invalid-documentation: DOCUMENTATION.name: required key not provided @ data['name']. Got None

Replaced 'cliconf' to 'name' under DOCUMENTATION in plugins/cliconf/os6.py
DOCUMENTATION = """
---
name: os6
short_description: Use os6 cliconf to run command on Dell OS6 platform
description:
  - This os6 plugin provides low level abstraction apis for
    sending and receiving CLI commands from Dell OS6 network devices.
"""


<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
